### PR TITLE
Add explanation on max number of IDs to request

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Public profiles can be retrieved without any prior authentication using getProfi
 
 ## Application ID
 
-In order to identify which applications are popular, better manage the resources devoted to the API, and look for places where new API functions might improve app efficiency, API queries accept an optional "appId" parameter. The value has no impact on the results of the query, but is used when the API interaciton is logged. App developers are encourged to add an "appId=abc123" parameter to their API queries. The ID can contain letters, digits, underscore, and hyphen. For example:
+In order to identify which applications are popular, better manage the resources devoted to the API, and look for places where new API functions might improve app efficiency, API queries accept an optional "appId" parameter. The value has no impact on the results of the query, but is used when the API interaction is logged. App developers are encourged to add an "appId=abc123" parameter to their API queries. The ID can contain letters, digits, underscore, and hyphen. For example:
 
 ```
 curl 'https://api.wikitree.com/api.php?action=getProfile&key=Franklin-10478&appId=SpectacularTree'

--- a/getAncestors.md
+++ b/getAncestors.md
@@ -35,7 +35,7 @@ If you request the "bio" field (the text biography for a Person profile), the de
 
 ### resolveRedirect
 
-Generally if you start at a valid profile and follow use the ids associated with relationships (mother, father) you should get a valid/complete profile in return. However, in some circumstances you may end up requesting a profile that has been merged away into another profile, or otherwise is redirected. If you set resolveRedirect=1 in your POST to the API, then any profiles that would be returned that are redirections will be followed to their end point, and *that* final profile will be returned.
+Generally if you start at a valid profile and follow the ids associated with relationships (mother, father) you should get a valid/complete profile in return. However, in some circumstances you may end up requesting a profile that has been merged away into another profile, or otherwise is redirected. If you set resolveRedirect=1 in your action, then any profiles that would be returned that are redirections will be followed to their end point, and *that* final profile will be returned.
 
 ## Results
 

--- a/getBio.md
+++ b/getBio.md
@@ -24,7 +24,7 @@ If you request the "bio" field (the text biography for a Person profile), the de
 
 ### resolveRedirect
 
-Generally if you start at a valid profile and follow use the ids associated with relationships (mother, father) you should get a valid/complete profile in return. However, in some circumstances you may end up requesting a profile that has been merged away into another profile, or otherwise is redirected. If you set resolveRedirect=1 in your POST to the API, then any profiles that would be returned that are redirections will be followed to their end point, and *that* final profile will be returned.
+Generally if you start at a valid profile and follow use the ids associated with relationships (mother, father) you should get a valid/complete profile in return. However, in some circumstances you may end up requesting a profile that has been merged away into another profile, or otherwise is redirected. If you set resolveRedirect=1 in your action, then any profiles that would be returned that are redirections will be followed to their end point, and *that* final profile will be returned.
 
 ## Results
 

--- a/getPeople.md
+++ b/getPeople.md
@@ -18,7 +18,9 @@
 
 ### keys
 
-The "keys" parameter is used to indicate the initial set of which profile(s) to return. The value is a comma-delimited list of key values, where each key can be either a "WikiTree Id" or a "User Id". The WikiTree Id is the name used after "/wiki/" in the URL of the page. For example, for https://www.wikitree.com/wiki/Shoshone-1, the WikiTree Id is "Shonshone-1". The User Id is the value used in all of the person-to-person relationship references, like Father and Mother, and is the "Id" value returned for a profile. The maximum number of keys that can be requested is 100 when any combination of `ancestors`, `descendants` or `nuclear` is used, otherwise the maximum is 1000.
+The "keys" parameter is used to indicate the initial set of which profile(s) to return. The value is a comma-delimited list of key values, where each key can be either a "WikiTree Id" or a "User Id". The WikiTree Id is the name used after "/wiki/" in the URL of the page. For example, for https://www.wikitree.com/wiki/Shoshone-1, the WikiTree Id is "Shonshone-1". The User Id is the value used in all of the person-to-person relationship references, like Father and Mother, and is the "Id" value returned for a profile. 
+
+The maximum number of keys that can be requested is 100 when any combination of `ancestors`, `descendants` or `nuclear` is used, otherwise the maximum is 1000.
 
 ### fields
 

--- a/getPeople.md
+++ b/getPeople.md
@@ -18,7 +18,7 @@
 
 ### keys
 
-The "keys" parameter is used to indicate the initial set of which profile(s) to return. The value is a comma-delimited list of key values, where each key can be either a "WikiTree Id" or a "User Id". The WikiTree Id is the name used after "/wiki/" in the URL of the page. For example, for https://www.wikitree.com/wiki/Shoshone-1, the WikiTree Id is "Shonshone-1". The User Id is the value used in all of the person-to-person relationship references, like Father and Mother, and is the "Id" value returned for a profile.
+The "keys" parameter is used to indicate the initial set of which profile(s) to return. The value is a comma-delimited list of key values, where each key can be either a "WikiTree Id" or a "User Id". The WikiTree Id is the name used after "/wiki/" in the URL of the page. For example, for https://www.wikitree.com/wiki/Shoshone-1, the WikiTree Id is "Shonshone-1". The User Id is the value used in all of the person-to-person relationship references, like Father and Mother, and is the "Id" value returned for a profile. The maximum number of keys that can be requested is 100 when any combination of `ancestors`, `descendants` or `nuclear` is used, otherwise the maximum is 1000.
 
 ### fields
 

--- a/getPerson.md
+++ b/getPerson.md
@@ -32,7 +32,7 @@ If you request the "bio" field (the text biography for a Person profile), the de
 
 ### resolveRedirect
 
-Generally if you start at a valid profile and follow use the ids associated with relationships (mother, father) you should get a valid/complete profile in return. However, in some circumstances you may end up requesting a profile that has been merged away into another profile, or otherwise is redirected. If you set resolveRedirect=1 in your POST to the API, then any profiles that would be returned that are redirections will be followed to their end point, and *that* final profile will be returned.
+Generally if you start at a valid profile and follow use the ids associated with relationships (mother, father) you should get a valid/complete profile in return. However, in some circumstances you may end up requesting a profile that has been merged away into another profile, or otherwise is redirected. If you set resolveRedirect=1 in your action, then any profiles that would be returned that are redirections will be followed to their end point, and *that* final profile will be returned.
 
 ## Results
 

--- a/getPhotos.md
+++ b/getPhotos.md
@@ -18,7 +18,7 @@ The "key" parameter is used to indicate which profile to return. This can be eit
 
 ### resolveRedirect
 
-Generally if you start at a valid profile and follow use the ids associated with relationships (mother, father) you should get a valid/complete profile in return. However, in some circumstances you may end up requesting a profile that has been merged away into another profile, or otherwise is redirected. If you set resolveRedirect=1 in your POST to the API, then any profiles that would be returned that are redirections will be followed to their end point, and *that* final profile will be returned.
+Generally if you start at a valid profile and follow use the ids associated with relationships (mother, father) you should get a valid/complete profile in return. However, in some circumstances you may end up requesting a profile that has been merged away into another profile, or otherwise is redirected. If you set resolveRedirect=1 in your action, then any profiles that would be returned that are redirections will be followed to their end point, and *that* final profile will be returned.
 
 ### limit
 


### PR DESCRIPTION
See https://www.wikitree.com/g2g/1686937/wikitree-api-max-profiles-for-getpeople

Also, replace the limiting POST by action as that covers the options better.